### PR TITLE
Fix __version__ export and tests

### DIFF
--- a/src/analysta/__init__.py
+++ b/src/analysta/__init__.py
@@ -2,11 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .diff import hello        # src/analysta/__init__.py
-__all__ = ["hello"]
+"""Public Analysta interface."""
 
-"""Public Analysta interface"""
 from .delta import Delta
+from .diff import hello
+from .__about__ import __version__
 
-__all__: list[str] = ["Delta"]
-__version__: str = "0.0.1"
+__all__ = ["Delta", "hello"]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,21 @@
+import importlib.util
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import analysta
+
+
+def test_version_matches_about():
+    spec = importlib.util.spec_from_file_location("about", "src/analysta/__about__.py")
+    about = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(about)
+    assert analysta.__version__ == about.__version__
+
+
+def test_all_exports():
+    expected = {"Delta", "hello"}
+    assert set(analysta.__all__) == expected
+    for name in expected:
+        assert hasattr(analysta, name)


### PR DESCRIPTION
## Summary
- export `__version__` from `__about__`
- consolidate `__all__` and re-export `hello`
- test the public API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5709c290833086c42e4f3cd89513