### PR TITLE
Fix README word wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/analysta.svg)](https://pypi.org/project/analysta)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/analysta.svg)](https://pypi.org/project/analysta)
 
-**A Python library for comparing pandas DataFrames using primary keys, tolerances, and audit-friendly diffs.**  
-Easily detect mismatches, missing rows, and cell-level changes between two datasets.
+**A Python library for comparing pandas DataFrames using primary keys,**
+tolerances, and audit-friendly diffs.** Easily detect mismatches,
+missing rows, and cell-level changes between two datasets.
 
 -----
 


### PR DESCRIPTION
## Summary
- ensure lines don't break words

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a58a9f0908330ba43d26009e0b362