### PR TITLE
Implement whitespace trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ print(delta.changed("price"))    # Row(s) where price changed
 - Tolerant numeric diffs (absolute & relative)
 - Highlight changed columns
 - Built for analysts, not just engineers
+- Automatic trimming of leading/trailing whitespace
 - CLI and HTML reporting coming soon
 
 ## 📄 License

--- a/src/analysta/__init__.py
+++ b/src/analysta/__init__.py
@@ -5,7 +5,7 @@
 """Public Analysta interface."""
 
 from .delta import Delta
-from .diff import hello
+from .diff import hello, trim_whitespace
 from .__about__ import __version__
 
-__all__ = ["Delta", "hello"]
+__all__ = ["Delta", "hello", "trim_whitespace"]

--- a/src/analysta/delta.py
+++ b/src/analysta/delta.py
@@ -4,6 +4,8 @@ Copyright (c) 2025  MIT License
 """
 from __future__ import annotations
 
+from .diff import trim_whitespace
+
 import pandas as pd
 
 
@@ -30,8 +32,8 @@ class Delta:  # pylint: disable=too-few-public-methods
         abs_tol: float = 0.0,
         rel_tol: float = 0.0,
     ) -> None:
-        self.df_a = df_a.copy()
-        self.df_b = df_b.copy()
+        self.df_a = trim_whitespace(df_a.copy())
+        self.df_b = trim_whitespace(df_b.copy())
         self.keys = [keys] if isinstance(keys, str) else list(keys)
         self.abs_tol = abs_tol
         self.rel_tol = rel_tol

--- a/src/analysta/diff.py
+++ b/src/analysta/diff.py
@@ -1,1 +1,17 @@
-def hello(): print("Hello, Analysta!")
+"""Utility helpers for :mod:`analysta`."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def hello() -> None:
+    """Print a friendly greeting."""
+
+    print("Hello, Analysta!")
+
+
+def trim_whitespace(df: pd.DataFrame) -> pd.DataFrame:
+    """Return *df* with leading/trailing whitespace stripped from strings."""
+
+    return df.map(lambda x: x.strip() if isinstance(x, str) else x)

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -17,3 +17,14 @@ def test_changed_returns_only_modified_rows():
     expected = pd.DataFrame({"id": [2], "price_a": [200], "price_b": [250]})
     pd.testing.assert_frame_equal(result, expected)
 
+
+def test_whitespace_is_trimmed():
+    df_a = pd.DataFrame({"id": [" 1"], "name": ["Alice "]})
+    df_b = pd.DataFrame({"id": ["1"], "name": ["Alice"]})
+
+    delta = Delta(df_a, df_b, keys="id")
+
+    assert delta.unmatched_a.empty
+    assert delta.unmatched_b.empty
+    assert delta.mismatches.empty
+

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -15,7 +15,7 @@ def test_version_matches_about():
 
 
 def test_all_exports():
-    expected = {"Delta", "hello"}
+    expected = {"Delta", "hello", "trim_whitespace"}
     assert set(analysta.__all__) == expected
     for name in expected:
         assert hasattr(analysta, name)

--- a/tests/test_trim_whitespace.py
+++ b/tests/test_trim_whitespace.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from analysta import trim_whitespace
+
+
+def test_trim_whitespace_removes_spaces():
+    df = pd.DataFrame({"a": [" x ", "y"], "b": [1, 2]})
+    result = trim_whitespace(df)
+    expected = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- add a `trim_whitespace` helper and export it
- strip whitespace from DataFrames in `Delta`
- document trimming capability in README
- test trimming behavior and public API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a617a38088330b876a52e454dbf61