### PR TITLE
Add duplicate detection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Python 3.8 or higher is required.
 ## ⚡ Quick Example
 
 ```python
-from analysta import Delta
+from analysta import Delta, find_duplicates
 import pandas as pd
 
 df1 = pd.DataFrame({"id": [1, 2], "price": [100, 200]})
@@ -37,6 +37,7 @@ delta = Delta(df1, df2, keys=["id"])
 print(delta.unmatched_a)         # Rows in df1 not in df2
 print(delta.unmatched_b)         # Rows in df2 not in df1
 print(delta.changed("price"))    # Row(s) where price changed
+print(find_duplicates(df1, column="id"))  # Duplicates by column
 ```
 
 ## ✨ Features
@@ -46,6 +47,7 @@ print(delta.changed("price"))    # Row(s) where price changed
 - Highlight changed columns
 - Built for analysts, not just engineers
 - Automatic trimming of leading/trailing whitespace
+- Detect duplicate rows with optional counts
 - CLI and HTML reporting coming soon
 
 ## 📄 License

--- a/src/analysta/__about__.py
+++ b/src/analysta/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Diego-Ignacio Ortiz <31400790+dunkel000@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/src/analysta/__init__.py
+++ b/src/analysta/__init__.py
@@ -5,7 +5,7 @@
 """Public Analysta interface."""
 
 from .delta import Delta
-from .diff import hello, trim_whitespace
+from .diff import hello, trim_whitespace, find_duplicates
 from .__about__ import __version__
 
-__all__ = ["Delta", "hello", "trim_whitespace"]
+__all__ = ["Delta", "hello", "trim_whitespace", "find_duplicates"]

--- a/src/analysta/diff.py
+++ b/src/analysta/diff.py
@@ -15,3 +15,39 @@ def trim_whitespace(df: pd.DataFrame) -> pd.DataFrame:
     """Return *df* with leading/trailing whitespace stripped from strings."""
 
     return df.map(lambda x: x.strip() if isinstance(x, str) else x)
+
+
+def find_duplicates(
+    df: pd.DataFrame,
+    column: str | None = None,
+    *,
+    counts: bool = False,
+) -> pd.DataFrame:
+    """Return duplicate rows or their counts.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame to check for duplicates.
+    column : str | None, optional
+        Column to consider when looking for duplicates. If ``None`` (default),
+        all columns are used.
+    counts : bool, default ``False``
+        When ``True``, return a DataFrame with duplicate values and how many
+        times they appear instead of the duplicated rows themselves.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Either the duplicated rows or a count of duplicates by the selected
+        column(s).
+    """
+
+    subset = [column] if column is not None else df.columns.tolist()
+    mask = df.duplicated(subset=subset, keep=False)
+    dupes = df.loc[mask].copy()
+
+    if counts:
+        return dupes.groupby(subset).size().reset_index(name="count")
+
+    return dupes.reset_index(drop=True)

--- a/tests/test_find_duplicates.py
+++ b/tests/test_find_duplicates.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from analysta import find_duplicates
+
+
+def test_find_duplicates_returns_rows():
+    df = pd.DataFrame({"id": [1, 1, 2], "val": [10, 10, 20]})
+    result = find_duplicates(df)
+    expected = pd.DataFrame({"id": [1, 1], "val": [10, 10]})
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_find_duplicates_counts():
+    df = pd.DataFrame({"id": [1, 1, 2, 2, 2]})
+    result = find_duplicates(df, column="id", counts=True)
+    expected = pd.DataFrame({"id": [1, 2], "count": [2, 3]})
+    pd.testing.assert_frame_equal(result, expected)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -15,7 +15,7 @@ def test_version_matches_about():
 
 
 def test_all_exports():
-    expected = {"Delta", "hello", "trim_whitespace"}
+    expected = {"Delta", "hello", "trim_whitespace", "find_duplicates"}
     assert set(analysta.__all__) == expected
     for name in expected:
         assert hasattr(analysta, name)


### PR DESCRIPTION
## Summary
- add `find_duplicates` helper
- expose helper in public API
- document duplicate detection in README
- bump version to 0.0.3
- test `find_duplicates` and update API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a64d580308330af7a81789d7b4b32