### PR TITLE
Add tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_delta_additional.py
+++ b/tests/test_delta_additional.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from analysta import Delta
+
+
+def test_unmatched_rows_detected():
+    df_a = pd.DataFrame({"id": [1, 2], "price": [10, 20]})
+    df_b = pd.DataFrame({"id": [2, 3], "price": [20, 30]})
+    delta = Delta(df_a, df_b, keys="id")
+
+    expected_a = pd.DataFrame({"id": [1], "price_a": [10.0], "price_b": [np.nan]})
+    expected_b = pd.DataFrame({"id": [3], "price_a": [np.nan], "price_b": [30.0]})
+
+    pd.testing.assert_frame_equal(delta.unmatched_a.reset_index(drop=True), expected_a)
+    pd.testing.assert_frame_equal(delta.unmatched_b.reset_index(drop=True), expected_b)
+    assert delta.mismatches.empty
+
+
+def test_numeric_tolerance():
+    df_a = pd.DataFrame({"id": [1, 2], "value": [100.0, 200.005]})
+    df_b = pd.DataFrame({"id": [1, 2], "value": [100.0, 200.0]})
+    delta = Delta(df_a, df_b, keys="id", abs_tol=0.01)
+
+    assert delta.mismatches.empty

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,0 +1,11 @@
+import os
+import sys
+from analysta import hello
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+def test_hello_prints_greeting(capsys):
+    hello()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "Hello, Analysta!"


### PR DESCRIPTION
## Summary
- test unmatched rows and numeric tolerance in `Delta`
- test greeting output of `hello`
- run tests in GitHub Actions across Python versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599b01f34483309e06d550863f9c02