### PR TITLE
Fix trim_whitespace to handle string columns correctly

### DIFF
--- a/src/analysta/diff.py
+++ b/src/analysta/diff.py
@@ -14,7 +14,16 @@ def hello() -> None:
 def trim_whitespace(df: pd.DataFrame) -> pd.DataFrame:
     """Return *df* with leading/trailing whitespace stripped from strings."""
 
-    return df.map(lambda x: x.strip() if isinstance(x, str) else x)
+    trimmed = df.copy()
+
+    for column in trimmed.columns:
+        series = trimmed[column]
+        if pd.api.types.is_object_dtype(series) or pd.api.types.is_string_dtype(series):
+            trimmed[column] = series.apply(
+                lambda value: value.strip() if isinstance(value, str) else value
+            )
+
+    return trimmed
 
 
 def find_duplicates(


### PR DESCRIPTION
## Summary
- update `trim_whitespace` to strip string/object columns without altering other types
- ensure the helper returns a copy compatible with `Delta` initialization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee7c103dd48330ae64a5d714eec741