### PR TITLE
Add Delta tolerance and helper coverage

### DIFF
--- a/tests/test_delta_additional.py
+++ b/tests/test_delta_additional.py
@@ -26,3 +26,61 @@ def test_numeric_tolerance():
     delta = Delta(df_a, df_b, keys="id", abs_tol=0.01)
 
     assert delta.mismatches.empty
+
+
+def test_relative_tolerance_allows_proportional_differences():
+    df_a = pd.DataFrame({"id": [1, 2], "value": [100.05, 50.0]})
+    df_b = pd.DataFrame({"id": [1, 2], "value": [100.0, 50.0]})
+
+    delta = Delta(df_a, df_b, keys="id", rel_tol=0.001)
+
+    assert delta.mismatches.empty
+
+
+def test_relative_tolerance_detects_excess_difference():
+    df_a = pd.DataFrame({"id": [1], "value": [100.25]})
+    df_b = pd.DataFrame({"id": [1], "value": [100.0]})
+
+    delta = Delta(df_a, df_b, keys="id", rel_tol=0.001)
+
+    expected = pd.DataFrame({"id": [1], "value_a": [100.25], "value_b": [100.0]})
+    pd.testing.assert_frame_equal(delta.mismatches.reset_index(drop=True), expected)
+
+
+def test_multi_key_comparison_detects_mismatches():
+    df_a = pd.DataFrame(
+        {
+            "id": [1, 1, 2],
+            "region": ["NA", "EU", "EU"],
+            "value": [10.0, 20.0, 30.0],
+            "label": ["ok", "fine", "matched"],
+        }
+    )
+    df_b = pd.DataFrame(
+        {
+            "id": [1, 1, 2],
+            "region": ["NA", "EU", "EU"],
+            "value": [10.0, 21.5, 30.0],
+            "label": ["ok", "Fine", "matched"],
+        }
+    )
+
+    delta = Delta(df_a, df_b, keys=["id", "region"])
+
+    expected = pd.DataFrame(
+        {
+            "id": [1],
+            "region": ["EU"],
+            "value_a": [20.0],
+            "label_a": ["fine"],
+            "value_b": [21.5],
+            "label_b": ["Fine"],
+        }
+    )
+
+    pd.testing.assert_frame_equal(delta.mismatches.reset_index(drop=True), expected)
+    result = delta.changed("value").reset_index(drop=True)
+    pd.testing.assert_frame_equal(
+        result,
+        expected[["id", "region", "value_a", "value_b"]],
+    )

--- a/tests/test_find_duplicates.py
+++ b/tests/test_find_duplicates.py
@@ -18,3 +18,45 @@ def test_find_duplicates_counts():
     result = find_duplicates(df, column="id", counts=True)
     expected = pd.DataFrame({"id": [1, 2], "count": [2, 3]})
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_find_duplicates_uses_all_columns_when_column_none():
+    df = pd.DataFrame(
+        {
+            "id": [1, 1, 1],
+            "val": [10, 10, 10],
+            "note": ["alpha", "alpha", "beta"],
+        }
+    )
+
+    result = find_duplicates(df)
+    expected = pd.DataFrame(
+        {
+            "id": [1, 1],
+            "val": [10, 10],
+            "note": ["alpha", "alpha"],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_find_duplicates_preserves_non_subset_columns():
+    df = pd.DataFrame(
+        {
+            "id": [1, 1, 2],
+            "city": ["NY", "SF", "LA"],
+            "value": [100, 200, 300],
+        }
+    )
+
+    result = find_duplicates(df, column="id")
+    expected = pd.DataFrame(
+        {
+            "id": [1, 1],
+            "city": ["NY", "SF"],
+            "value": [100, 200],
+        }
+    )
+
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)

--- a/tests/test_trim_whitespace.py
+++ b/tests/test_trim_whitespace.py
@@ -11,3 +11,12 @@ def test_trim_whitespace_removes_spaces():
     result = trim_whitespace(df)
     expected = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_trim_whitespace_preserves_non_string_objects():
+    df = pd.DataFrame({"mixed": [" value ", 10, None], "num": [1, 2, 3]})
+
+    result = trim_whitespace(df)
+
+    expected = pd.DataFrame({"mixed": ["value", 10, None], "num": [1, 2, 3]})
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- add Delta test cases for relative tolerance handling and multi-key mismatches
- extend find_duplicates coverage for default column selection and subset behavior
- ensure trim_whitespace preserves non-string object values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee7cf9a9708330bcba568a8c806bf5