### PR TITLE
Raise minimum Python version to 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ missing rows, and cell-level changes between two datasets.
 pip install analysta
 ```
 
-Python 3.8 or higher is required.
+Python 3.10 or higher is required.
 
 For a concise import, you can alias the package:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "analysta"
 dynamic = ["version"]
 description = 'DataFrame Toolkit for Analysts'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,8 +16,6 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary
- update the project metadata to require Python 3.10+
- refresh the README to document the new minimum supported version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69021a5ed34c8330a258a442b78f71b2