### PR TITLE
Add DataFrame quality audit helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ clean = nl.trim_whitespace(df)
 print(clean)
 ```
 
+### Auditing data quality
+
+```python
+import analysta as nl
+import pandas as pd
+
+df = pd.DataFrame(
+    {
+        "id": [1, 2, 3],
+        "age": ["34", 28, None],
+        "signup_date": ["2024-01-01", "01/03/2024", "31-12-2023"],
+    }
+)
+
+issues = nl.audit_dataframe(
+    df,
+    allow_nulls={"age": False},
+    expected_dtypes={"age": "int64"},
+    date_formats={"signup_date": ["%Y-%m-%d", "%m/%d/%Y"]},
+)
+print(issues)
+```
+
 ## ✨ Features
 
 - Key-based row comparison: `"A not in B"` and vice versa
@@ -90,6 +113,7 @@ print(clean)
 - Built for analysts, not just engineers
 - Automatic trimming of leading/trailing whitespace
 - Detect duplicate rows with optional counts
+- Data quality audit helpers for nulls, types, and dates
 - CLI and HTML reporting coming soon
 
 ## 📄 License

--- a/src/analysta/__init__.py
+++ b/src/analysta/__init__.py
@@ -6,6 +6,7 @@
 
 from .delta import Delta
 from .diff import hello, trim_whitespace, find_duplicates
+from .quality import audit_dataframe
 from .__about__ import __version__
 
-__all__ = ["Delta", "hello", "trim_whitespace", "find_duplicates"]
+__all__ = ["Delta", "hello", "trim_whitespace", "find_duplicates", "audit_dataframe"]

--- a/src/analysta/quality.py
+++ b/src/analysta/quality.py
@@ -1,0 +1,211 @@
+"""Utilities for auditing DataFrame quality issues."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import (
+    is_datetime64_any_dtype,
+    is_float_dtype,
+    is_integer_dtype,
+    is_numeric_dtype,
+    is_string_dtype,
+    pandas_dtype,
+)
+
+Issue = dict[str, str]
+
+
+def audit_dataframe(
+    df: pd.DataFrame,
+    *,
+    allow_nulls: Mapping[str, bool] | None = None,
+    expected_dtypes: Mapping[str, Any] | None = None,
+    date_formats: Mapping[str, str | Sequence[str]] | None = None,
+) -> pd.DataFrame:
+    """Inspect *df* for basic data quality issues.
+
+    Parameters
+    ----------
+    df:
+        The DataFrame to validate.
+    allow_nulls:
+        Mapping of column name to ``True``/``False`` indicating whether nulls are
+        allowed for the column. Columns omitted from the mapping are not
+        validated.
+    expected_dtypes:
+        Mapping of column name to an expected dtype (``numpy``/``pandas`` dtype,
+        dtype string, or Python type).
+    date_formats:
+        Mapping of column name to the ``strftime`` format string (or sequence of
+        strings) that should successfully parse values in the column.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A DataFrame with columns ``column``, ``issue`` and ``details``.
+    """
+
+    issues: list[Issue] = []
+    allow_nulls = allow_nulls or {}
+    expected_dtypes = expected_dtypes or {}
+    date_formats = date_formats or {}
+
+    for column, allow in allow_nulls.items():
+        if allow:
+            continue
+        if column not in df.columns:
+            continue
+        series = df[column]
+        null_mask = series.isna()
+        if null_mask.any():
+            indices = list(series.index[null_mask])
+            issues.append(
+                {
+                    "column": column,
+                    "issue": "null_forbidden",
+                    "details": _summarise_values("null", indices),
+                }
+            )
+
+    for column, expected in expected_dtypes.items():
+        if column not in df.columns:
+            continue
+        series = df[column]
+        non_null_series = series[~series.isna()]
+        if non_null_series.empty:
+            continue
+        mismatch_mask = _type_mismatch_mask(non_null_series, expected)
+        if mismatch_mask is None:
+            continue
+        if mismatch_mask.any():
+            invalid = non_null_series[mismatch_mask]
+            issues.append(
+                {
+                    "column": column,
+                    "issue": "dtype_mismatch",
+                    "details": _summarise_invalid_values(expected, invalid),
+                }
+            )
+
+    for column, formats in date_formats.items():
+        if column not in df.columns:
+            continue
+        series = df[column]
+        non_null_series = series[~series.isna()]
+        if non_null_series.empty:
+            continue
+        if is_datetime64_any_dtype(non_null_series):
+            continue
+        invalid_mask = _date_invalid_mask(non_null_series, formats)
+        if invalid_mask.any():
+            invalid = non_null_series[invalid_mask]
+            issues.append(
+                {
+                    "column": column,
+                    "issue": "invalid_date_format",
+                    "details": _summarise_values(invalid, list(invalid.index)),
+                }
+            )
+
+    if issues:
+        result = pd.DataFrame(issues, columns=["column", "issue", "details"])
+        return result.sort_values(["column", "issue"], ignore_index=True)
+    return pd.DataFrame(columns=["column", "issue", "details"])
+
+
+def _type_mismatch_mask(series: pd.Series, expected: Any) -> pd.Series | None:
+    category = _normalise_dtype(expected)
+    if category == "integer":
+        converted = pd.to_numeric(series, errors="coerce")
+        fractional = converted % 1
+        fractional_mask = pd.Series(
+            ~np.isclose(fractional.fillna(0), 0), index=converted.index
+        )
+        fractional_mask &= converted.notna()
+        invalid = series.notna() & (converted.isna() | fractional_mask)
+        return invalid
+    if category == "float":
+        converted = pd.to_numeric(series, errors="coerce")
+        invalid = series.notna() & converted.isna()
+        return invalid
+    if category == "string":
+        invalid = series.notna() & ~series.map(lambda value: isinstance(value, str))
+        return invalid
+    if category == "datetime":
+        parsed = pd.to_datetime(series, errors="coerce")
+        invalid = series.notna() & parsed.isna()
+        return invalid
+    return None
+
+
+def _normalise_dtype(expected: Any) -> str:
+    try:
+        dtype = pandas_dtype(expected)
+    except (TypeError, ValueError):
+        dtype = None
+
+    if dtype is not None:
+        if is_integer_dtype(dtype):
+            return "integer"
+        if is_float_dtype(dtype) or (is_numeric_dtype(dtype) and not is_integer_dtype(dtype)):
+            return "float"
+        if is_string_dtype(dtype):
+            return "string"
+        if is_datetime64_any_dtype(dtype):
+            return "datetime"
+
+    if isinstance(expected, type):
+        if issubclass(expected, (int, np.integer)):
+            return "integer"
+        if issubclass(expected, (float, np.floating)):
+            return "float"
+        if issubclass(expected, (str, bytes)):
+            return "string"
+
+    if isinstance(expected, str):
+        lower = expected.lower()
+        if "int" in lower:
+            return "integer"
+        if any(token in lower for token in ("float", "double", "numeric", "number")):
+            return "float"
+        if "datetime" in lower or lower.startswith("date"):
+            return "datetime"
+        if lower in {"str", "string", "object"}:
+            return "string"
+
+    return "unknown"
+
+
+def _date_invalid_mask(series: pd.Series, formats: str | Sequence[str]) -> pd.Series:
+    if isinstance(formats, str):
+        formats_to_try: list[str] = [formats]
+    elif isinstance(formats, Sequence) and not isinstance(formats, (bytes, bytearray)):
+        formats_to_try = [str(fmt) for fmt in formats]
+    else:
+        formats_to_try = [str(formats)]
+
+    valid_mask = pd.Series(False, index=series.index)
+    for fmt in formats_to_try:
+        parsed = pd.to_datetime(series, format=fmt, errors="coerce")
+        valid_mask |= parsed.notna()
+    return ~valid_mask
+
+
+def _summarise_values(values: Any, indices: list[Any]) -> str:
+    if isinstance(values, pd.Series):
+        sample = values.astype(str).head(5).tolist()
+    elif hasattr(values, "__iter__") and not isinstance(values, (str, bytes)):
+        sample = list(map(str, list(values)[:5]))
+    else:
+        sample = [str(values)]
+    return f"Rows {indices}; samples: {sample}"
+
+
+def _summarise_invalid_values(expected: Any, invalid: pd.Series) -> str:
+    sample_values = invalid.astype(str).head(5).tolist()
+    indices = list(invalid.index)
+    return f"Expected {expected!r}; rows {indices}; samples: {sample_values}"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -15,7 +15,7 @@ def test_version_matches_about():
 
 
 def test_all_exports():
-    expected = {"Delta", "hello", "trim_whitespace", "find_duplicates"}
+    expected = {"Delta", "hello", "trim_whitespace", "find_duplicates", "audit_dataframe"}
     assert set(analysta.__all__) == expected
     for name in expected:
         assert hasattr(analysta, name)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import sys
+
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from analysta import audit_dataframe
+
+
+def test_audit_dataframe_flags_forbidden_nulls() -> None:
+    df = pd.DataFrame({"id": [1, 2, 3], "value": [10, None, 30]})
+
+    issues = audit_dataframe(df, allow_nulls={"value": False})
+
+    assert not issues.empty
+    null_issue = issues[issues["issue"] == "null_forbidden"].iloc[0]
+    assert null_issue["column"] == "value"
+    assert "Rows" in null_issue["details"]
+    assert "1" in null_issue["details"]  # index of the null value
+
+
+def test_audit_dataframe_detects_type_mismatches() -> None:
+    df = pd.DataFrame(
+        {
+            "int_col": [1, 2.5, "3", "bad"],
+            "float_col": [0.1, "0.2", "oops", 4],
+        }
+    )
+
+    issues = audit_dataframe(
+        df,
+        expected_dtypes={"int_col": "int64", "float_col": "float64"},
+    )
+
+    assert {"int_col", "float_col"}.issubset(set(issues["column"]))
+
+    int_issue = issues[issues["column"] == "int_col"].iloc[0]
+    assert "2.5" in int_issue["details"]
+    assert "bad" in int_issue["details"]
+
+    float_issue = issues[issues["column"] == "float_col"].iloc[0]
+    assert "oops" in float_issue["details"]
+
+
+def test_audit_dataframe_validates_date_formats() -> None:
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "01/02/2024", "31-12-2023"],
+        }
+    )
+
+    issues = audit_dataframe(df, date_formats={"date": ["%Y-%m-%d", "%m/%d/%Y"]})
+
+    assert "invalid_date_format" in issues["issue"].values
+    date_issue = issues[issues["issue"] == "invalid_date_format"].iloc[0]
+    assert date_issue["column"] == "date"
+    assert "31-12-2023" in date_issue["details"]


### PR DESCRIPTION
## Summary
- add an audit_dataframe helper for null, dtype, and date validation and export it from the public API
- document the data quality audit workflow in the README and add comprehensive tests

## Testing
- python -m pytest


------
https://chatgpt.com/codex/tasks/task_e_690aa312fa0483309897bcd5f09d356e