### PR TITLE
Add CSV and Excel import/export helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ clean = nl.trim_whitespace(df)
 print(clean)
 ```
 
+### Working with CSV and Excel files
+
+```python
+import analysta as nl
+
+transactions = nl.read_csv("transactions.csv", dtype={"id": "Int64"})
+nl.write_csv(transactions, "transactions_clean.csv", index=False)
+
+sales = nl.read_excel("sales.xlsx", sheet_name="Raw")
+nl.write_excel(sales, "sales_clean.xlsx", sheet_name="Clean", index=False)
+```
+
+> [!TIP]
+> Excel support relies on `openpyxl` for `.xlsx` files. Install it with
+> `pip install openpyxl` if it is not already available in your environment.
+
 ### Auditing data quality
 
 ```python
@@ -113,6 +129,7 @@ print(issues)
 - Built for analysts, not just engineers
 - Automatic trimming of leading/trailing whitespace
 - Detect duplicate rows with optional counts
+- CSV and Excel import/export helpers that delegate to pandas
 - Data quality audit helpers for nulls, types, and dates
 - CLI and HTML reporting coming soon
 

--- a/src/analysta/__init__.py
+++ b/src/analysta/__init__.py
@@ -6,7 +6,18 @@
 
 from .delta import Delta
 from .diff import hello, trim_whitespace, find_duplicates
+from .io import read_csv, write_csv, read_excel, write_excel
 from .quality import audit_dataframe
 from .__about__ import __version__
 
-__all__ = ["Delta", "hello", "trim_whitespace", "find_duplicates", "audit_dataframe"]
+__all__ = [
+    "Delta",
+    "hello",
+    "trim_whitespace",
+    "find_duplicates",
+    "audit_dataframe",
+    "read_csv",
+    "write_csv",
+    "read_excel",
+    "write_excel",
+]

--- a/src/analysta/io.py
+++ b/src/analysta/io.py
@@ -1,0 +1,123 @@
+"""Convenient CSV and Excel helpers built on top of pandas."""
+
+from __future__ import annotations
+
+import os
+from typing import IO, Any, BinaryIO, TextIO
+
+import pandas as pd
+from pandas import DataFrame
+
+FilePath = str | os.PathLike[str]
+ReadCsvBuffer = TextIO | BinaryIO
+WriteCsvBuffer = TextIO | BinaryIO
+ReadExcelBuffer = IO[bytes]
+WriteExcelBuffer = IO[bytes]
+
+
+def read_csv(
+    path_or_buffer: FilePath | ReadCsvBuffer,
+    /,
+    **kwargs: Any,
+) -> DataFrame:
+    """Return a DataFrame by delegating to :func:`pandas.read_csv`.
+
+    Parameters
+    ----------
+    path_or_buffer:
+        A file path string, pathlib.Path, or file-like object to read the CSV
+        data from.
+    **kwargs:
+        Additional keyword arguments passed directly to
+        :func:`pandas.read_csv` (e.g. ``dtype`` or ``parse_dates``).
+    """
+
+    return pd.read_csv(path_or_buffer, **kwargs)
+
+
+def write_csv(
+    dataframe: DataFrame,
+    path_or_buffer: FilePath | WriteCsvBuffer,
+    /,
+    *,
+    index: bool | None = None,
+    **kwargs: Any,
+) -> None:
+    """Write a DataFrame to CSV using :meth:`pandas.DataFrame.to_csv`.
+
+    Parameters
+    ----------
+    dataframe:
+        The DataFrame to be written to disk or a buffer.
+    path_or_buffer:
+        A file path string, pathlib.Path, or file-like object to write the CSV
+        into.
+    index:
+        Whether to include the DataFrame index in the output. ``None`` keeps
+        pandas' default behaviour (``True``).
+    **kwargs:
+        Additional keyword arguments forwarded to
+        :meth:`pandas.DataFrame.to_csv` (e.g. ``sep`` or ``encoding``).
+    """
+
+    to_csv_kwargs: dict[str, Any] = {}
+    if index is not None:
+        to_csv_kwargs["index"] = index
+    dataframe.to_csv(path_or_buffer, **to_csv_kwargs, **kwargs)
+
+
+def read_excel(
+    path_or_buffer: FilePath | ReadExcelBuffer,
+    /,
+    **kwargs: Any,
+) -> DataFrame:
+    """Return a DataFrame by delegating to :func:`pandas.read_excel`.
+
+    Parameters
+    ----------
+    path_or_buffer:
+        A file path string, pathlib.Path, or file-like object containing Excel
+        data.
+    **kwargs:
+        Additional keyword arguments passed directly to
+        :func:`pandas.read_excel` (e.g. ``sheet_name`` or ``engine``).
+    """
+
+    return pd.read_excel(path_or_buffer, **kwargs)
+
+
+def write_excel(
+    dataframe: DataFrame,
+    path_or_buffer: FilePath | WriteExcelBuffer,
+    /,
+    *,
+    sheet_name: str | None = None,
+    index: bool | None = None,
+    **kwargs: Any,
+) -> None:
+    """Write a DataFrame to Excel via :meth:`pandas.DataFrame.to_excel`.
+
+    Parameters
+    ----------
+    dataframe:
+        The DataFrame to be written to the Excel workbook.
+    path_or_buffer:
+        Destination path or Excel-compatible buffer.
+    sheet_name:
+        Optional sheet name for the exported data. ``None`` keeps pandas'
+        default (``"Sheet1"``).
+    index:
+        Whether to include the DataFrame index in the output. ``None`` keeps
+        pandas' default behaviour (``True``).
+    **kwargs:
+        Additional keyword arguments forwarded to
+        :meth:`pandas.DataFrame.to_excel` (e.g. ``engine``).
+    """
+
+    to_excel_kwargs: dict[str, Any] = {}
+    if sheet_name is not None:
+        to_excel_kwargs["sheet_name"] = sheet_name
+    if index is not None:
+        to_excel_kwargs["index"] = index
+
+    dataframe.to_excel(path_or_buffer, **to_excel_kwargs, **kwargs)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from analysta.io import read_csv, write_csv, read_excel, write_excel
+
+
+def test_csv_round_trip(tmp_path):
+    dataframe = pd.DataFrame({"id": [1, 2], "value": [10.5, 20.75]})
+    csv_path = tmp_path / "sample.csv"
+
+    write_csv(dataframe, csv_path, index=False)
+
+    result = read_csv(csv_path, dtype={"id": "int64"})
+
+    pdt.assert_frame_equal(result, dataframe)
+    assert str(result["id"].dtype) == "int64"
+
+
+def test_write_csv_invalid_option(tmp_path):
+    dataframe = pd.DataFrame({"id": [1]})
+
+    with pytest.raises(TypeError):
+        write_csv(dataframe, tmp_path / "bad.csv", invalid_kw=True)
+
+
+def test_excel_round_trip(tmp_path):
+    pytest.importorskip("openpyxl")
+
+    dataframe = pd.DataFrame({"id": [1, 2], "label": ["a", "b"]})
+    excel_path = tmp_path / "sample.xlsx"
+
+    write_excel(dataframe, excel_path, sheet_name="Data", index=False)
+
+    result = read_excel(excel_path, sheet_name="Data")
+
+    pdt.assert_frame_equal(result, dataframe)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -15,7 +15,17 @@ def test_version_matches_about():
 
 
 def test_all_exports():
-    expected = {"Delta", "hello", "trim_whitespace", "find_duplicates", "audit_dataframe"}
+    expected = {
+        "Delta",
+        "hello",
+        "trim_whitespace",
+        "find_duplicates",
+        "audit_dataframe",
+        "read_csv",
+        "write_csv",
+        "read_excel",
+        "write_excel",
+    }
     assert set(analysta.__all__) == expected
     for name in expected:
         assert hasattr(analysta, name)


### PR DESCRIPTION
## Summary
- add pandas-backed helpers for reading and writing CSV and Excel data
- expose the new I/O utilities through the public package API and document their usage
- cover the functionality with public API and round-trip tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690aa45ab1708330b9479bf4809342f9