### PR TITLE
Add expect_df entrypoint for natural language DataFrame checks

### DIFF
--- a/src/analysta/__init__.py
+++ b/src/analysta/__init__.py
@@ -8,6 +8,7 @@ from .delta import Delta
 from .diff import hello, trim_whitespace, find_duplicates
 from .io import read_csv, write_csv, read_excel, write_excel
 from .quality import audit_dataframe
+from .check import expect_df
 from .__about__ import __version__
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "trim_whitespace",
     "find_duplicates",
     "audit_dataframe",
+    "expect_df",
     "read_csv",
     "write_csv",
     "read_excel",

--- a/src/analysta/check.py
+++ b/src/analysta/check.py
@@ -1,0 +1,353 @@
+"""Natural language expectations for DataFrame validation.
+
+This module exposes :func:`expect_df`, a lightweight validator that turns
+human-friendly Analysta style phrases into column expectations and row rules.
+The parser aims to be permissive while still producing structured results that
+describe which expectations passed or failed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class ColumnExpectation:
+    """Column-level expectation derived from natural language.
+
+    Parameters
+    ----------
+    name:
+        Column name.
+    unique:
+        Whether the column should contain unique values.
+    dtype:
+        Expected data type category (``"integer"``, ``"float"``, ``"string"``,
+        or ``"datetime"``).
+    fmt:
+        Expected ``strftime`` format for datetime/text parsing.
+    allowed_values:
+        Optional allowed set of values.
+    regex:
+        Optional regular expression pattern that values must match.
+    allow_nulls:
+        Whether nulls are allowed. ``None`` means no explicit expectation.
+    """
+
+    name: str
+    unique: bool = False
+    dtype: str | None = None
+    fmt: str | None = None
+    allowed_values: set[str] | None = None
+    regex: str | None = None
+    allow_nulls: bool | None = None
+
+
+@dataclass
+class ColumnResult:
+    column: str
+    passed: bool
+    diagnostics: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RowRule:
+    description: str
+    expression: str
+
+
+@dataclass
+class RowRuleResult:
+    description: str
+    passed: bool
+    failing_indices: list[int] = field(default_factory=list)
+    message: str | None = None
+
+
+@dataclass
+class ExpectationReport:
+    passed: bool
+    column_results: list[ColumnResult] = field(default_factory=list)
+    row_results: list[RowRuleResult] = field(default_factory=list)
+
+
+def expect_df(
+    df: pd.DataFrame, expectations: str | Iterable[str], /, *, row_rules: Iterable[str] | None = None
+) -> ExpectationReport:
+    """Validate a DataFrame against Analysta-style expectations.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> data = pd.DataFrame({"id": [1, 1], "status": ["ok", "bad"]})
+    >>> report = expect_df(
+    ...     data,
+    ...     [
+    ...         "expect column id to be unique and not null",
+    ...         "column status: allowed values {ok, pending}",
+    ...     ],
+    ... )
+    >>> report.passed
+    False
+    """
+
+    column_expectations, parsed_row_rules = _parse_expectations(expectations)
+    if row_rules:
+        parsed_row_rules.extend(_parse_row_rules(row_rules))
+
+    column_results: list[ColumnResult] = []
+    for expectation in column_expectations:
+        column_results.append(_validate_column(df, expectation))
+
+    row_results: list[RowRuleResult] = []
+    for rule in parsed_row_rules:
+        row_results.append(_validate_row_rule(df, rule))
+
+    passed = all(result.passed for result in column_results + row_results)
+    return ExpectationReport(passed=passed, column_results=column_results, row_results=row_results)
+
+
+def _parse_expectations(
+    expectations: str | Iterable[str],
+) -> tuple[list[ColumnExpectation], list[RowRule]]:
+    if isinstance(expectations, str):
+        lines = [line.strip() for line in expectations.splitlines() if line.strip()]
+    else:
+        lines = [str(item).strip() for item in expectations if str(item).strip()]
+
+    column_expectations: list[ColumnExpectation] = []
+    row_rules: list[RowRule] = []
+
+    for line in lines:
+        lowered = line.lower()
+        if lowered.startswith(("rows must", "every row must", "expect rows")):
+            row_rules.extend(_parse_row_rules([line]))
+            continue
+
+        column_match = re.search(
+            r"(?:expect\s+)?column\s+(?P<name>[\w .-]+?)(?:\s*(?:to|:)?\s+)(?P<body>.+)",
+            line,
+            flags=re.IGNORECASE,
+        )
+        if column_match:
+            name = column_match.group("name").strip()
+            body = column_match.group("body").strip()
+        elif ":" in line:
+            name, body = [segment.strip() for segment in line.split(":", maxsplit=1)]
+            name = name.replace("column", "", 1).strip()
+        else:
+            # If we cannot parse the column name, ignore the expectation.
+            continue
+
+        expectation = _parse_column_body(name, body)
+        column_expectations.append(expectation)
+
+    return column_expectations, row_rules
+
+
+def _parse_column_body(name: str, body: str) -> ColumnExpectation:
+    expectation = ColumnExpectation(name=name)
+
+    tokens = re.split(r"[,;]|\band\b", body, flags=re.IGNORECASE)
+    for raw_token in tokens:
+        token = raw_token.strip()
+        lowered = token.lower()
+        if not token:
+            continue
+        if "unique" in lowered:
+            expectation.unique = True
+            continue
+        if any(phrase in lowered for phrase in ("not null", "no null", "non-null")):
+            expectation.allow_nulls = False
+            continue
+        if "allow null" in lowered:
+            expectation.allow_nulls = True
+            continue
+        dtype = _extract_dtype(lowered)
+        if dtype is not None:
+            expectation.dtype = dtype
+        fmt = _extract_format(token)
+        if fmt is not None:
+            expectation.fmt = fmt
+        allowed = _extract_allowed_values(token)
+        if allowed:
+            expectation.allowed_values = allowed
+        regex = _extract_regex(token)
+        if regex is not None:
+            expectation.regex = regex
+
+    return expectation
+
+
+def _extract_dtype(token: str) -> str | None:
+    if any(word in token for word in ("integer", "int")):
+        return "integer"
+    if any(word in token for word in ("float", "double", "numeric")):
+        return "float"
+    if any(word in token for word in ("string", "text")):
+        return "string"
+    if "datetime" in token or "date" in token:
+        return "datetime"
+    return None
+
+
+def _extract_format(token: str) -> str | None:
+    match = re.search(r"format\s+(.+)", token, flags=re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _extract_allowed_values(token: str) -> set[str] | None:
+    match = re.search(r"allowed values?[^\w]*(.+)", token, flags=re.IGNORECASE)
+    if not match:
+        match = re.search(r"values?\s+in\s+(.+)", token, flags=re.IGNORECASE)
+    if not match:
+        return None
+
+    values_part = match.group(1).strip()
+    values_part = values_part.strip("{}[]()")
+    raw_values = [part.strip() for part in values_part.split("or")]
+    values: list[str] = []
+    for raw in raw_values:
+        if not raw:
+            continue
+        values.extend([segment.strip().strip("'\"") for segment in raw.split(",") if segment.strip()])
+
+    if values:
+        return set(values)
+    return None
+
+
+def _extract_regex(token: str) -> str | None:
+    match = re.search(r"regex\s+(.+)", token, flags=re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    match = re.search(r"match(?:es)?\s+(.+)", token, flags=re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _parse_row_rules(rules: Iterable[str]) -> list[RowRule]:
+    parsed: list[RowRule] = []
+    for rule in rules:
+        if not rule:
+            continue
+        text = rule.strip()
+        lowered = text.lower()
+        if "satisfy" in lowered:
+            expression = text.split("satisfy", maxsplit=1)[1].strip()
+        elif "must" in lowered:
+            expression = text.split("must", maxsplit=1)[1].strip()
+        else:
+            expression = text
+        parsed.append(RowRule(description=text, expression=expression))
+    return parsed
+
+
+def _validate_column(df: pd.DataFrame, expectation: ColumnExpectation) -> ColumnResult:
+    diagnostics: list[str] = []
+
+    if expectation.name not in df.columns:
+        diagnostics.append("column missing")
+        return ColumnResult(column=expectation.name, passed=False, diagnostics=diagnostics)
+
+    series = df[expectation.name]
+
+    if expectation.allow_nulls is False:
+        null_mask = series.isna()
+        if null_mask.any():
+            indices = list(series.index[null_mask])
+            diagnostics.append(f"nulls forbidden; rows {indices}")
+
+    if expectation.unique:
+        duplicates = series[series.duplicated(keep=False)]
+        if not duplicates.empty:
+            duplicate_indices = list(duplicates.index)
+            samples = duplicates.head(5).tolist()
+            diagnostics.append(
+                f"expected unique values; duplicate rows {duplicate_indices}; samples: {samples}"
+            )
+
+    if expectation.dtype:
+        dtype_diagnostics = _dtype_diagnostics(series, expectation)
+        diagnostics.extend(dtype_diagnostics)
+
+    if expectation.allowed_values:
+        invalid_mask = series.notna() & ~series.astype(str).isin(expectation.allowed_values)
+        if invalid_mask.any():
+            invalid = series[invalid_mask]
+            diagnostics.append(
+                f"unexpected values; rows {list(invalid.index)}; samples: {invalid.astype(str).head(5).tolist()}"
+            )
+
+    if expectation.regex:
+        pattern = re.compile(expectation.regex)
+        str_values = series.dropna().astype(str)
+        invalid_mask = ~str_values.map(lambda value: bool(pattern.fullmatch(value)))
+        if invalid_mask.any():
+            invalid = str_values[invalid_mask]
+            diagnostics.append(
+                f"regex mismatch /{expectation.regex}/; rows {list(invalid.index)}; samples: {invalid.head(5).tolist()}"
+            )
+
+    passed = not diagnostics
+    return ColumnResult(column=expectation.name, passed=passed, diagnostics=diagnostics)
+
+
+def _dtype_diagnostics(series: pd.Series, expectation: ColumnExpectation) -> list[str]:
+    diagnostics: list[str] = []
+    dtype = expectation.dtype
+    if dtype == "integer":
+        converted = pd.to_numeric(series, errors="coerce")
+        fractional = (converted % 1).fillna(0)
+        invalid_mask = series.notna() & (converted.isna() | ~np.isclose(fractional, 0))
+    elif dtype == "float":
+        converted = pd.to_numeric(series, errors="coerce")
+        invalid_mask = series.notna() & converted.isna()
+    elif dtype == "string":
+        invalid_mask = series.notna() & ~series.map(lambda value: isinstance(value, str))
+    elif dtype == "datetime":
+        parsed = pd.to_datetime(series, format=expectation.fmt, errors="coerce")
+        invalid_mask = series.notna() & parsed.isna()
+    else:
+        return diagnostics
+
+    if invalid_mask.any():
+        invalid = series[invalid_mask]
+        details = f"expected {dtype}; rows {list(invalid.index)}; samples: {invalid.astype(str).head(5).tolist()}"
+        if dtype == "datetime" and expectation.fmt:
+            details += f"; format={expectation.fmt}"
+        diagnostics.append(details)
+    return diagnostics
+
+
+def _validate_row_rule(df: pd.DataFrame, rule: RowRule) -> RowRuleResult:
+    try:
+        evaluated = df.eval(rule.expression)
+    except Exception as exc:  # pragma: no cover - rare parse errors
+        return RowRuleResult(
+            description=rule.description,
+            passed=False,
+            failing_indices=list(range(len(df))),
+            message=f"failed to evaluate expression: {exc}",
+        )
+
+    if isinstance(evaluated, pd.Series):
+        mask = evaluated.astype(bool)
+    else:
+        mask = pd.Series(bool(evaluated), index=df.index)
+
+    failing = list(df.index[~mask])
+    passed = not failing
+    message = None
+    if failing:
+        message = f"rows failing rule '{rule.expression}': {failing}"
+    return RowRuleResult(description=rule.description, passed=passed, failing_indices=failing, message=message)
+

--- a/tests/test_expect_df.py
+++ b/tests/test_expect_df.py
@@ -1,0 +1,72 @@
+import pandas as pd
+
+from analysta.check import expect_df
+
+
+def test_expect_df_parses_natural_language_expectations():
+    df = pd.DataFrame(
+        {
+            "id": [1, 1, 2],
+            "age": [25, "x", None],
+            "status": ["active", "inactive", "pending"],
+        }
+    )
+
+    expectations = """
+    expect column id to be unique and not null
+    column age: integer, allow nulls
+    column status should have allowed values {active, inactive}
+    """
+
+    report = expect_df(df, expectations)
+
+    assert report.passed is False
+    assert len(report.column_results) == 3
+
+    id_result = next(result for result in report.column_results if result.column == "id")
+    assert id_result.passed is False
+    assert any("unique" in diagnostic for diagnostic in id_result.diagnostics)
+
+    age_result = next(result for result in report.column_results if result.column == "age")
+    assert age_result.passed is False
+    assert any("integer" in diagnostic for diagnostic in age_result.diagnostics)
+
+    status_result = next(
+        result for result in report.column_results if result.column == "status"
+    )
+    assert status_result.passed is False
+    assert any("unexpected values" in diagnostic for diagnostic in status_result.diagnostics)
+
+
+def test_expect_df_reports_row_rules_and_formats():
+    df = pd.DataFrame(
+        {
+            "order_id": [1, 2, 3],
+            "placed_at": ["2024-01-01", "2024-01-02", "2024-13-01"],
+            "code": ["AB12", "ZZ99", "bad"],
+            "amount": [10.0, 0.0, -5.0],
+        }
+    )
+
+    expectations = [
+        "expect column order_id to be unique and not null",
+        "column placed_at: datetime format %Y-%m-%d",
+        "column code should match regex ^[A-Z]{2}\\d{2}$",
+        "column amount: float",
+    ]
+
+    report = expect_df(df, expectations, row_rules=["rows must satisfy amount >= 0"])
+
+    assert report.passed is False
+
+    placed_at = next(result for result in report.column_results if result.column == "placed_at")
+    assert placed_at.passed is False
+    assert any("datetime" in diagnostic for diagnostic in placed_at.diagnostics)
+
+    code = next(result for result in report.column_results if result.column == "code")
+    assert code.passed is False
+    assert any("regex" in diagnostic for diagnostic in code.diagnostics)
+
+    row_rule = report.row_results[0]
+    assert row_rule.passed is False
+    assert row_rule.failing_indices == [2]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -21,6 +21,7 @@ def test_all_exports():
         "trim_whitespace",
         "find_duplicates",
         "audit_dataframe",
+        "expect_df",
         "read_csv",
         "write_csv",
         "read_excel",


### PR DESCRIPTION
## Summary
- add expect_df entrypoint that parses Analysta-style expectations into column and row validations
- implement validation models, parsing helpers, and diagnostics reporting utilities
- export the new API and cover it with tests including public API verification

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d440071a88330a3494fff279e168c)