### PR TITLE
Add duplicates alias to simplify examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ delta = nl.Delta(df1, df2, keys="id")
 print(delta.unmatched_a)         # → id=1
 print(delta.unmatched_b)         # → id=4
 print(delta.changed("price"))    # → id=3
-print(nl.find_duplicates(df1, column="id"))  # Duplicates by column
+print(nl.duplicates(df1, column="id"))  # Duplicates by column
 ```
 
 ## 📚 More Examples
@@ -71,8 +71,12 @@ print(delta.changed("value"))  # diff 0.005 > 0.001 → id=2
 
 ```python
 df = pd.DataFrame({"id": [1, 1, 2, 2, 2]})
-print(nl.find_duplicates(df, column="id", counts=True))
+print(nl.duplicates(df, column="id", counts=True))
 ```
+
+> [!NOTE]
+> `nl.duplicates` is a short alias for `nl.find_duplicates` so existing code
+> keeps working while examples stay concise.
 
 ### Trimming whitespace
 

--- a/src/analysta/__init__.py
+++ b/src/analysta/__init__.py
@@ -5,7 +5,7 @@
 """Public Analysta interface."""
 
 from .delta import Delta
-from .diff import hello, trim_whitespace, find_duplicates
+from .diff import hello, trim_whitespace, find_duplicates, duplicates
 from .io import read_csv, write_csv, read_excel, write_excel
 from .quality import audit_dataframe
 from .check import expect_df
@@ -15,6 +15,7 @@ __all__ = [
     "Delta",
     "hello",
     "trim_whitespace",
+    "duplicates",
     "find_duplicates",
     "audit_dataframe",
     "expect_df",

--- a/src/analysta/diff.py
+++ b/src/analysta/diff.py
@@ -60,3 +60,18 @@ def find_duplicates(
         return dupes.groupby(subset).size().reset_index(name="count")
 
     return dupes.reset_index(drop=True)
+
+
+def duplicates(
+    df: pd.DataFrame,
+    column: str | None = None,
+    *,
+    counts: bool = False,
+) -> pd.DataFrame:
+    """Convenience alias for :func:`find_duplicates`.
+
+    This shorter name keeps examples concise while preserving
+    ``find_duplicates`` for backward compatibility.
+    """
+
+    return find_duplicates(df, column=column, counts=counts)

--- a/tests/test_find_duplicates.py
+++ b/tests/test_find_duplicates.py
@@ -1,26 +1,31 @@
 import os
 import sys
+
 import pandas as pd
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-from analysta import find_duplicates
+from analysta import duplicates, find_duplicates
 
 
-def test_find_duplicates_returns_rows():
+@pytest.mark.parametrize("func", [find_duplicates, duplicates])
+def test_find_duplicates_returns_rows(func):
     df = pd.DataFrame({"id": [1, 1, 2], "val": [10, 10, 20]})
-    result = find_duplicates(df)
+    result = func(df)
     expected = pd.DataFrame({"id": [1, 1], "val": [10, 10]})
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
-def test_find_duplicates_counts():
+@pytest.mark.parametrize("func", [find_duplicates, duplicates])
+def test_find_duplicates_counts(func):
     df = pd.DataFrame({"id": [1, 1, 2, 2, 2]})
-    result = find_duplicates(df, column="id", counts=True)
+    result = func(df, column="id", counts=True)
     expected = pd.DataFrame({"id": [1, 2], "count": [2, 3]})
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_find_duplicates_uses_all_columns_when_column_none():
+@pytest.mark.parametrize("func", [find_duplicates, duplicates])
+def test_find_duplicates_uses_all_columns_when_column_none(func):
     df = pd.DataFrame(
         {
             "id": [1, 1, 1],
@@ -29,7 +34,7 @@ def test_find_duplicates_uses_all_columns_when_column_none():
         }
     )
 
-    result = find_duplicates(df)
+    result = func(df)
     expected = pd.DataFrame(
         {
             "id": [1, 1],
@@ -41,7 +46,8 @@ def test_find_duplicates_uses_all_columns_when_column_none():
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
-def test_find_duplicates_preserves_non_subset_columns():
+@pytest.mark.parametrize("func", [find_duplicates, duplicates])
+def test_find_duplicates_preserves_non_subset_columns(func):
     df = pd.DataFrame(
         {
             "id": [1, 1, 2],
@@ -50,7 +56,7 @@ def test_find_duplicates_preserves_non_subset_columns():
         }
     )
 
-    result = find_duplicates(df, column="id")
+    result = func(df, column="id")
     expected = pd.DataFrame(
         {
             "id": [1, 1],

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -19,6 +19,7 @@ def test_all_exports():
         "Delta",
         "hello",
         "trim_whitespace",
+        "duplicates",
         "find_duplicates",
         "audit_dataframe",
         "expect_df",


### PR DESCRIPTION
## Summary
- add a new `duplicates` alias for `find_duplicates` while keeping the original helper
- update public API expectations and duplicate tests to cover both names
- refresh README examples to use the shorter `nl.duplicates` name and note the alias

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e88ad20488330ae363ceafd068bbe)